### PR TITLE
use filePath instead of fileName (issue #6)

### DIFF
--- a/fcp/winc/microsoft_windows_sysmon_operational/microsoft_windows_sysmon.sdkkeyvaluefilereader.properties
+++ b/fcp/winc/microsoft_windows_sysmon_operational/microsoft_windows_sysmon.sdkkeyvaluefilereader.properties
@@ -81,7 +81,7 @@ event.transportProtocol=Protocol
 # Added various image/target image so that file name/file hash
 # matching is easier next to each other and there's no analyst confusion what the hash is for (Thanks StevenD)
 # Note that submessages also set this field
-event.fileName=__oneOf(TargetFilename,ImageLoaded,TargetImage,Image)
+event.filePath=__oneOf(TargetFilename,ImageLoaded,TargetImage,Image)
 #
 event.fileCreateTime=__parseMultipleTimeStamp(CreationUtcTime,"MM/dd/yyyy HH\:mm\:ss.SSS","yyyy-MM-dd HH\:mm\:ss.SSS")
 event.oldFileCreateTime=__parseMultipleTimeStamp(PreviousCreationUtcTime,"MM/dd/yyyy HH\:mm\:ss.SSS","yyyy-MM-dd HH\:mm\:ss.SSS")
@@ -213,7 +213,7 @@ conditionalmap[0].mappings[0].event.deviceCustomString3=CurrentDirectory
 conditionalmap[0].mappings[0].event.deviceCustomString4Label=__stringConstant("Parent Process GUID")
 conditionalmap[0].mappings[0].event.deviceCustomString4=ParentProcessGuid
 conditionalmap[0].mappings[0].event.destinationServiceName=Product
-conditionalmap[0].mappings[0].event.oldFileName=OriginalFileName
+conditionalmap[0].mappings[0].event.oldFilePath=OriginalFileName
 #
 ###############################################################################################################
 #
@@ -430,7 +430,7 @@ conditionalmap[0].mappings[10].event.deviceEventClassId=__stringConstant("Sysmon
 conditionalmap[0].mappings[11].values=12
 conditionalmap[0].mappings[11].event.message=__concatenate("Registry: ",EventType," Object: ",TargetObject," by process: ",Image)
 conditionalmap[0].mappings[11].event.deviceEventClassId=__stringConstant("SysmonTask-SYSMON_REG_KEY")
-conditionalmap[0].mappings[11].event.fileName=TargetObject
+conditionalmap[0].mappings[11].event.filePath=TargetObject
 #
 ###############################################################################################################
 # Event ID 13: Registry value set
@@ -448,7 +448,7 @@ conditionalmap[0].mappings[12].event.message=__concatenate("Registry Value: ",Ta
 conditionalmap[0].mappings[12].event.deviceEventClassId=__stringConstant("SysmonTask-SYSMON_REG_SETVALUE")
 conditionalmap[0].mappings[12].event.deviceCustomString1Label=__stringConstant("Registry Value Details")
 conditionalmap[0].mappings[12].event.deviceCustomString1=Details
-conditionalmap[0].mappings[12].event.fileName=TargetObject
+conditionalmap[0].mappings[12].event.filePath=TargetObject
 
 #
 ###############################################################################################################
@@ -465,8 +465,8 @@ conditionalmap[0].mappings[12].event.fileName=TargetObject
 conditionalmap[0].mappings[13].values=14
 conditionalmap[0].mappings[13].event.message=__concatenate("Registry Object renamed: ",TargetObject," New name: ",NewName)
 conditionalmap[0].mappings[13].event.deviceEventClassId=__stringConstant("SysmonTask-SYSMON_REG_NAME")
-conditionalmap[0].mappings[13].event.oldFileName=TargetObject
-conditionalmap[0].mappings[13].event.fileName=NewName
+conditionalmap[0].mappings[13].event.oldFilePath=TargetObject
+conditionalmap[0].mappings[13].event.filePath=NewName
 #
 ###############################################################################################################
 # Event ID 15: File stream created
@@ -492,7 +492,7 @@ conditionalmap[0].mappings[14].event.deviceEventClassId=__stringConstant("Sysmon
 conditionalmap[0].mappings[15].values=16
 conditionalmap[0].mappings[15].event.message=__concatenate("Sysmon configuration changed. Configuration: ",Configuration)
 conditionalmap[0].mappings[15].event.deviceEventClassId=__stringConstant("SysmonTask-SYSMON_SERVICE_CONFIGURATION_CHANGE")
-conditionalmap[0].mappings[15].event.fileName=Configuration
+conditionalmap[0].mappings[15].event.filePath=Configuration
 conditionalmap[0].mappings[15].event.fileHash=__regexToken(ConfigurationFileHash,".*SHA1=(\\w+).*")
 #
 ###############################################################################################################


### PR DESCRIPTION
EventData elements such as Image contain the full path to the file. Therefore, these need to be mapped to (old)FilePath instead of (old)fileName.