### PR TITLE
Change catch all name from "Sysmon Event" to "Unparsed Event" to fit …

### DIFF
--- a/fcp/winc/microsoft_windows_sysmon_operational/microsoft_windows_sysmon.sdkkeyvaluefilereader.properties
+++ b/fcp/winc/microsoft_windows_sysmon_operational/microsoft_windows_sysmon.sdkkeyvaluefilereader.properties
@@ -638,7 +638,7 @@ conditionalmap[0].mappings[22].event.deviceCustomString2=Description
 #
 ###############################################################################################################
 # catch all event for future changes / additions
-conditionalmap[0].mappings[23].event.name=__stringConstant("Sysmon Event")
+conditionalmap[0].mappings[23].event.name=__stringConstant("Unparsed Event")
 #
 ###############################################################################################################
 


### PR DESCRIPTION
…in with ArcSight standard

ArcSight standard is "Unparsed Event".  Changing from "Sysmon Event" to "Unparsed Event" will comply with ArcSight standard and allow content based on "Unparsed Event" to expand to cover Sysmon FlexConnector.