### PR TITLE
Replace __regexToken with __regexTokenNoWarning

### DIFF
--- a/fcp/winc/microsoft_windows_sysmon_operational/microsoft_windows_sysmon.sdkkeyvaluefilereader.properties
+++ b/fcp/winc/microsoft_windows_sysmon_operational/microsoft_windows_sysmon.sdkkeyvaluefilereader.properties
@@ -94,12 +94,12 @@ event.fileId=FileVersion
 # By default SHA256 maps to the fileHash field
 # The user has options to add additional Hash formats which are added to the relevant "additionaldata" field 
 # These can be mapped at the Console or this parser can be updated below.
-event.fileHash=__regexToken(Hashes,".*SHA256=(\\w+).*")
+event.fileHash=__regexTokenNoWarning(Hashes,".*SHA256=(\\w+).*")
 #
 # Commented out non-default settings - these can be reset if used in an organisation
-# additionaldata.Hash_SHA1=__regexToken(Hashes,".*SHA1=(\\w+).*")
-additionaldata.Hash_MD5=__regexToken(Hashes,".*MD5=(\\w+).*")
-# additionaldata.Hash_SHA256=__regexToken(Hashes,".*SHA256=(\\w+).*")
+# additionaldata.Hash_SHA1=__regexTokenNoWarning(Hashes,".*SHA1=(\\w+).*")
+additionaldata.Hash_MD5=__regexTokenNoWarning(Hashes,".*MD5=(\\w+).*")
+# additionaldata.Hash_SHA256=__regexTokenNoWarning(Hashes,".*SHA256=(\\w+).*")
 
 # Device Mappings
 event.deviceProcessId=__safeToInteger(ProcessId)


### PR DESCRIPTION
This eliminates agent.log warnings like:

[2019-10-27 18:25:47,398][WARN ][default.com.arcsight.agent.parsers.operation.regexTokenOperation][getResult] No match between string [SHA256=C75CFD1385DB48FFDF5E65946E2F695CA25D36D7C173C8D40361BC56F737668A] and regex [.*MD5=(\w+).*]
[2019-10-27 18:25:47,413][WARN ][default.com.arcsight.agent.parsers.operation.regexTokenOperation][getResult] No match between string [SHA256=C75CFD1385DB48FFDF5E65946E2F695CA25D36D7C173C8D40361BC56F737668A] and regex [.*SHA1=(\w+).*]