### PR TITLE
Updated parser to reflect Sysmon v11

### DIFF
--- a/acp/categorizer/current/microsoft/sysmon.csv
+++ b/acp/categorizer/current/microsoft/sysmon.csv
@@ -22,3 +22,4 @@ SysmonTask-SYSMON_WMI_CONSUMER,/Host/Resource/File,/Access,,/Success,/Informatio
 SysmonTask-SYSMON_WMI_BINDING,/Host/Resource/File,/Access,,/Success,/Informational/Warning,/Operating System,/Operating System,/Attack Lifecycle/Install,Source
 SysmonTask-SYSMON_ERROR,/Execute/Response,/Communicate,,/Success,/Informational/Error,/Operating System,/Operating System,,Source
 SysmonTask-DNS_QUERY,/Host/Application/Service,/Communicate/Query,,/Success,/Informational,Operating System,/Operating System,,Source
+SysmonTask-SYSMON_FILE_DELETE,/Host/Resource/File,/Delete,,/Success,/Informational,/Operating System,/Operating System,/Attack Lifecycle/Install,Source

--- a/fcp/winc/microsoft_windows_sysmon_operational/microsoft_windows_sysmon.map.csv
+++ b/fcp/winc/microsoft_windows_sysmon_operational/microsoft_windows_sysmon.map.csv
@@ -21,4 +21,5 @@ event.externalId,set.event.name
 20,WmiEventConsumer activity detected
 21,WmiEventConsumerToFilter activity detected
 22,DNS Query
+23,File deleted
 255,Error report

--- a/fcp/winc/microsoft_windows_sysmon_operational/microsoft_windows_sysmon.sdkkeyvaluefilereader.properties
+++ b/fcp/winc/microsoft_windows_sysmon_operational/microsoft_windows_sysmon.sdkkeyvaluefilereader.properties
@@ -631,7 +631,9 @@ conditionalmap[0].mappings[21].event.deviceCustomString1=QueryResults
 # ProcessId: %3
 # Image: %4
 # TargetFilename: %5
-# CreationUtcTime: %6
+# Hashes: %6
+# IsExecutable: %7
+# Archived: %8
 
 conditionalmap[0].mappings[10].values=23
 conditionalmap[0].mappings[10].event.message=__concatenate("File: ",TargetFilename," deleted by: ",Image)

--- a/fcp/winc/microsoft_windows_sysmon_operational/microsoft_windows_sysmon.sdkkeyvaluefilereader.properties
+++ b/fcp/winc/microsoft_windows_sysmon_operational/microsoft_windows_sysmon.sdkkeyvaluefilereader.properties
@@ -635,9 +635,9 @@ conditionalmap[0].mappings[21].event.deviceCustomString1=QueryResults
 # IsExecutable: %7
 # Archived: %8
 
-conditionalmap[0].mappings[10].values=23
-conditionalmap[0].mappings[10].event.message=__concatenate("File: ",TargetFilename," deleted by: ",Image)
-conditionalmap[0].mappings[10].event.deviceEventClassId=__stringConstant("SysmonTask-SYSMON_FILE_DELETE")
+conditionalmap[0].mappings[22].values=23
+conditionalmap[0].mappings[22].event.message=__concatenate("File: ",TargetFilename," deleted by: ",Image)
+conditionalmap[0].mappings[22].event.deviceEventClassId=__stringConstant("SysmonTask-SYSMON_FILE_DELETE")
 #
 
 

--- a/fcp/winc/microsoft_windows_sysmon_operational/microsoft_windows_sysmon.sdkkeyvaluefilereader.properties
+++ b/fcp/winc/microsoft_windows_sysmon_operational/microsoft_windows_sysmon.sdkkeyvaluefilereader.properties
@@ -173,7 +173,7 @@ additionaldata.Company=Company
 # Conditional Map settings
 conditionalmap.count=1
 conditionalmap[0].field=event.externalId
-conditionalmap[0].mappings.count=24
+conditionalmap[0].mappings.count=25
 #
 ###############################################################################################################
 #

--- a/fcp/winc/microsoft_windows_sysmon_operational/microsoft_windows_sysmon.sdkkeyvaluefilereader.properties
+++ b/fcp/winc/microsoft_windows_sysmon_operational/microsoft_windows_sysmon.sdkkeyvaluefilereader.properties
@@ -626,23 +626,16 @@ conditionalmap[0].mappings[21].event.deviceCustomString1=QueryResults
 ###############################################################################################################
 # Event ID 23: File Delete
 # RuleName
-# UtcTime
-# ProcessGuid
-# ProcessId
-# QueryName
-# QueryStatus
-# QueryResults
-# Image
-#
-conditionalmap[0].mappings[22].values=23
-conditionalmap[0].mappings[22].event.message=__concatenate(EventType)
-conditionalmap[0].mappings[22].event.deviceEventClassId=__stringConstant("SysmonTask-fileDelete")
-conditionalmap[0].mappings[22].event.destinationHostName=QueryName
-conditionalmap[0].mappings[22].event.requestUrl=QueryName
-conditionalmap[0].mappings[22].event.deviceCustomNumber1Label=__stringConstant("Query Status")
-conditionalmap[0].mappings[22].event.deviceCustomNumber1=__safeToLong(QueryStatus)
-conditionalmap[0].mappings[22].event.deviceCustomString1Label=__stringConstant("Query Results")
-conditionalmap[0].mappings[22].event.deviceCustomString1=QueryResults
+# UtcTime: %1
+# ProcessGuid: %2
+# ProcessId: %3
+# Image: %4
+# TargetFilename: %5
+# CreationUtcTime: %6
+
+conditionalmap[0].mappings[10].values=23
+conditionalmap[0].mappings[10].event.message=__concatenate("File: ",TargetFilename," deleted by: ",Image)
+conditionalmap[0].mappings[10].event.deviceEventClassId=__stringConstant("SysmonTask-SYSMON_FILE_DELETE")
 #
 
 

--- a/fcp/winc/microsoft_windows_sysmon_operational/microsoft_windows_sysmon.sdkkeyvaluefilereader.properties
+++ b/fcp/winc/microsoft_windows_sysmon_operational/microsoft_windows_sysmon.sdkkeyvaluefilereader.properties
@@ -620,24 +620,50 @@ conditionalmap[0].mappings[21].event.deviceCustomNumber1=__safeToLong(QueryStatu
 conditionalmap[0].mappings[21].event.deviceCustomString1Label=__stringConstant("Query Results")
 conditionalmap[0].mappings[21].event.deviceCustomString1=QueryResults
 #
+
+###############################################################################################################
+# The Following Event was introduced in Sysmon v11
+###############################################################################################################
+# Event ID 23: File Delete
+# RuleName
+# UtcTime
+# ProcessGuid
+# ProcessId
+# QueryName
+# QueryStatus
+# QueryResults
+# Image
+#
+conditionalmap[0].mappings[22].values=23
+conditionalmap[0].mappings[22].event.message=__concatenate(EventType)
+conditionalmap[0].mappings[22].event.deviceEventClassId=__stringConstant("SysmonTask-fileDelete")
+conditionalmap[0].mappings[22].event.destinationHostName=QueryName
+conditionalmap[0].mappings[22].event.requestUrl=QueryName
+conditionalmap[0].mappings[22].event.deviceCustomNumber1Label=__stringConstant("Query Status")
+conditionalmap[0].mappings[22].event.deviceCustomNumber1=__safeToLong(QueryStatus)
+conditionalmap[0].mappings[22].event.deviceCustomString1Label=__stringConstant("Query Results")
+conditionalmap[0].mappings[22].event.deviceCustomString1=QueryResults
+#
+
+
 ###############################################################################################################
 # Event ID 255: Error report
 # UtcTime: %1
 # ID: %2
 # Description: %3
 
-conditionalmap[0].mappings[22].values=255
-conditionalmap[0].mappings[22].event.message=__concatenate("Sysmon Error ID: ",ID," Description: ",Description)
-conditionalmap[0].mappings[22].event.deviceEventClassId=__stringConstant("SysmonTask-SYSMON_ERROR")
-conditionalmap[0].mappings[22].event.deviceCustomString1Label=__stringConstant("ID")
-conditionalmap[0].mappings[22].event.deviceCustomString1=ID
-conditionalmap[0].mappings[22].event.deviceCustomString2Label=__stringConstant("Description")
-conditionalmap[0].mappings[22].event.deviceCustomString2=Description
+conditionalmap[0].mappings[23].values=255
+conditionalmap[0].mappings[23].event.message=__concatenate("Sysmon Error ID: ",ID," Description: ",Description)
+conditionalmap[0].mappings[23].event.deviceEventClassId=__stringConstant("SysmonTask-SYSMON_ERROR")
+conditionalmap[0].mappings[23].event.deviceCustomString1Label=__stringConstant("ID")
+conditionalmap[0].mappings[23].event.deviceCustomString1=ID
+conditionalmap[0].mappings[23].event.deviceCustomString2Label=__stringConstant("Description")
+conditionalmap[0].mappings[23].event.deviceCustomString2=Description
 
 #
 ###############################################################################################################
 # catch all event for future changes / additions
-conditionalmap[0].mappings[23].event.name=__stringConstant("Unparsed Event")
+conditionalmap[0].mappings[24].event.name=__stringConstant("Unparsed Event")
 #
 ###############################################################################################################
 

--- a/fcp/winc/microsoft_windows_sysmon_operational/sysmon.xml
+++ b/fcp/winc/microsoft_windows_sysmon_operational/sysmon.xml
@@ -821,6 +821,12 @@
 		<!--DATA: EventType, UtcTime, Operation, User, Name, Type, Destination, Consumer, Filter-->
 		<WmiEvent onmatch="include">
 		</WmiEvent>
+		
+		
+		<!--TESTING FILEDELETE-->
+		<FileDelete onmatch="exclude">
+		</FileDelete>
+
 
 	<!--SYSMON EVENT ID 255 : ERROR-->
 		<!--"This event is generated when an error occurred within Sysmon. They can happen if the system is under heavy load


### PR DESCRIPTION
All files were updated to reflect fileDelete addition introduced by Sysmon v11. The sysmon.xml will need to be updated with entries to try and avoid noise but for now it has been set to show that fileDelete is being parsed by the parser.